### PR TITLE
fix: upgrade Gemini model to gemini-3.7-flash

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,5 +97,5 @@ The tests cover the core functionality of the application, including image uploa
 
 - **`GOOGLE_CLOUD_PROJECT`**: (Required) Your Google Cloud project ID.
 - **`LOCATION`**: (Optional) The Google Cloud region to use. Defaults to `us-central1`.
-- **`MODEL_ID`**: (Optional) The ID of the Gemini model to use. Defaults to `gemini-2.5-flash`.
+- **`MODEL_ID`**: (Optional) The ID of the Gemini model to use. Defaults to `gemini-3.7-flash`.
 - **`STORAGE_BUCKET`**: (Optional) The name of your Google Cloud Storage bucket for image uploads. If not set, image uploads to GCS will be skipped.

--- a/main.py
+++ b/main.py
@@ -26,7 +26,7 @@ load_dotenv()
 
 PROJECT_ID = os.environ.get("GOOGLE_CLOUD_PROJECT")
 LOCATION = os.environ.get("LOCATION", "global")
-MODEL_ID = os.environ.get("MODEL_ID", "gemini-3-flash-preview")
+MODEL_ID = os.environ.get("MODEL_ID", "gemini-3.7-flash")
 STORAGE_BUCKET = os.environ.get("STORAGE_BUCKET")
 DEFAULT_CURRENCY = os.environ.get(
     "CURRENCY",


### PR DESCRIPTION
## What

Moves the model from the `gemini-3-flash-preview` endpoint to the stable `gemini-3.7-flash`.

The README also documented a *different* stale default (`gemini-2.5-flash`) than the code actually used, so the two contradicted each other. Both now say `gemini-3.7-flash`.

| File | Change |
|---|---|
| `main.py:29` | `MODEL_ID` default (used by three `generate_content` calls) |
| `README.md:100` | documented default |

## Verification

- Full suite: **25 passed**.
- `gemini-3.7-flash` confirmed live against Vertex AI (HTTP 200).

## Notes

No sampling parameters in this codebase, so nothing to clean up for the Gemini 3.x deprecation.
